### PR TITLE
Fixed date format bug in Firefox.

### DIFF
--- a/feeds/driveCache.php
+++ b/feeds/driveCache.php
@@ -9,13 +9,14 @@ include '../inc/pdoDB.php';
 
 function populateJSON($data){
 	global $jsonOutput;
+	$mDate = date("Y-m-d", strtotime($data->reading_date));
 	$jsonOutput.= '{"lon":'.$data->longitude.
 					', "lat":'.$data->latitude.
 					', "name": "",'.
 					'"current_value": "'.$data->reading_value.'",'.
 					'"cpm_value": "'.$data->alt_reading_value.'",'.
 					'"id": "'.$data->reading_id.'",'.
-					'"at": "'.$data->reading_date.'",'.
+					'"at": "'.$mDate.'",'.
 					'"label": "'.$data->unit_symbol.'"},';	
 }
 

--- a/feeds/driveCache.php
+++ b/feeds/driveCache.php
@@ -9,14 +9,13 @@ include '../inc/pdoDB.php';
 
 function populateJSON($data){
 	global $jsonOutput;
-	$mDate = date("Y-m-d", strtotime($data->reading_date));
 	$jsonOutput.= '{"lon":'.$data->longitude.
 					', "lat":'.$data->latitude.
 					', "name": "",'.
 					'"current_value": "'.$data->reading_value.'",'.
 					'"cpm_value": "'.$data->alt_reading_value.'",'.
 					'"id": "'.$data->reading_id.'",'.
-					'"at": "'.$mDate.'",'.
+					'"at": "'.$data->reading_date.'",'.
 					'"label": "'.$data->unit_symbol.'"},';	
 }
 

--- a/script/drive.js
+++ b/script/drive.js
@@ -552,7 +552,7 @@ $(document).ready(function()
          //console.log("------------");
         // -------------------------------------
 
-	var mDate = new Date(oJson.at);
+	var mDate = new Date(oJson.at.substr(0, 10));
 	//console.log("[Date]" + oJson.at);
 	var month = mDate.getMonth()+1 < 10 ? "0" + (mDate.getMonth()+1) : (mDate.getMonth()+1);
 	var elCurrentValue  = $('<p>').html("<span style=\"font-weight: bold;\">" + oJson.cpm_value + ' CPM</span> <br /><span style=\"font-weight: bold;\">'+ oJson.current_value + ' ' + oJson.label + '</span> derived dose');


### PR DESCRIPTION
Firefox can't handle date format "Y-m-d time". One of these commits changes driveCache.php to format the date before it's placed in the JSON. However, I realized that we may want to have the date available in the JSON, if not now, then later. Instead, I moved the format change to drive.js.
